### PR TITLE
Fix error where content-type is a missing header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.mb3364.http</groupId>
     <artifactId>async-http-client</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <packaging>jar</packaging>
 
     <name>async-http-client</name>

--- a/src/main/java/com/mb3364/http/StringHttpResponseHandler.java
+++ b/src/main/java/com/mb3364/http/StringHttpResponseHandler.java
@@ -15,17 +15,20 @@ public abstract class StringHttpResponseHandler extends HttpResponseHandler {
      */
     private static String extractContentCharset(Map<String, List<String>> headers) {
         List<String> contentTypes = headers.get("Content-Type");
-        String contentType = contentTypes.get(0);
-        String charset = null;
-        if (contentType != null) {
-            for (String param : contentType.replace(" ", "").split(";")) {
-                if (param.startsWith("charset=")) {
-                    charset = param.split("=", 2)[1];
-                    break;
+        if (contentTypes != null) {
+            String contentType = contentTypes.get(0);
+            String charset = null;
+            if (contentType != null) {
+                for (String param : contentType.replace(" ", "").split(";")) {
+                    if (param.startsWith("charset=")) {
+                        charset = param.split("=", 2)[1];
+                        break;
+                    }
                 }
             }
+            return charset;
         }
-        return charset;
+        return DEFAULT_CHARSET; // No content type header, return the default
     }
 
     /**


### PR DESCRIPTION
If content-type header is not found, it will now use the default charset when encoding the response string.
